### PR TITLE
Changing '@.' to '@' when accessing local variables

### DIFF
--- a/alight/core.coffee
+++ b/alight/core.coffee
@@ -105,20 +105,20 @@ do ->
     ext.push
         code: 'init'
         fn: ->
-            if @.directive.init
-                @.result = @.directive.init(@.element, @.expression, @.scope, @.env) or {}
-            if not f$.isObject(@.result)
-                @.result = {}
+            if @directive.init
+                @result = @directive.init(@element, @expression, @scope, @env) or {}
+            if not f$.isObject(@result)
+                @result = {}
 
     ext.push
         code: 'templateUrl'
         fn: ->
             ds = @
-            if @.directive.templateUrl
-                callback = @.makeDeferred()
+            if @directive.templateUrl
+                callback = @makeDeferred()
                 f$.ajax
                     cache: true
-                    url: @.directive.templateUrl
+                    url: @directive.templateUrl
                     success: (html) ->
                         ds.directive.template = html
                         callback()
@@ -127,38 +127,38 @@ do ->
     ext.push
         code: 'template'
         fn: ->
-            if @.directive.template
-                if @.element.nodeType is 1
-                    f$.html @.element, @.directive.template
-                else if @.element.nodeType is 8
+            if @directive.template
+                if @element.nodeType is 1
+                    f$.html @element, @directive.template
+                else if @element.nodeType is 8
                     el = document.createElement 'p'
-                    el.innerHTML = @.directive.template.trimLeft()
+                    el.innerHTML = @directive.template.trimLeft()
                     el = el.firstChild
-                    f$.after @.element, el
-                    @.element = el
-                    if not @.directive.scope
-                        @.directive.scope = true
+                    f$.after @element, el
+                    @element = el
+                    if not @directive.scope
+                        @directive.scope = true
 
     ext.push
         code: 'scope'
         fn: ->
-            if @.directive.scope
-                parentScope = @.scope
-                @.scope = parentScope.$new(@.directive.scope is 'isolate')
-                @.result.owner = true
-                @.doBinding = true
+            if @directive.scope
+                parentScope = @scope
+                @scope = parentScope.$new(@directive.scope is 'isolate')
+                @result.owner = true
+                @doBinding = true
 
     ext.push
         code: 'link'
         fn: ->
-            if @.directive.link
-                @.directive.link(@.element, @.expression, @.scope, @.env)
+            if @directive.link
+                @directive.link(@element, @expression, @scope, @env)
 
     ext.push
         code: 'scopeBinding'
         fn: ->
-            if @.doBinding
-                alight.applyBindings @.scope, @.element, { skip_attr:@.env.skippedAttr() }
+            if @doBinding
+                alight.applyBindings @scope, @element, { skip_attr:@env.skippedAttr() }
 
 
 testDirective = do ->
@@ -272,16 +272,16 @@ process = do ->
     takeAttr = (name, skip) ->
         if arguments.length is 1
             skip = true
-        for attr in @.attributes
+        for attr in @attributes
             if attr.attrName isnt name
                 continue
             if skip
                 attr.skip = true
-            value = f$.attr @.element, name
+            value = f$.attr @element, name
             return value or true
 
     skippedAttr = ->
-        for attr in @.attributes
+        for attr in @attributes
             if not attr.skip
                 continue
             attr.attrName

--- a/alight/node.coffee
+++ b/alight/node.coffee
@@ -48,36 +48,36 @@ self.root = (conf) ->
 Root = (conf) ->
     conf = conf or {}
 
-    @.nodeHead = null
-    @.nodeTail = null
-    @.private = {}
-    @.watchers =    # $finishBinding, $finishScan, $any
+    @nodeHead = null
+    @nodeTail = null
+    @private = {}
+    @watchers =    # $finishBinding, $finishScan, $any
         any: []
         finishBinding: []
         finishScan: []
         finishScanOnce: []
-    @.status = null
+    @status = null
 
     # helpers
-    @.extraLoop = false
-    @.finishBinding_lock = false
-    @.lateScan = false
+    @extraLoop = false
+    @finishBinding_lock = false
+    @lateScan = false
 
     if conf.useObserver
-        @.obList = []  # contain fired watchers
-        @.observer = alight.observer.create()
-        @.privateOb = @.observer.observe @.private
+        @obList = []  # contain fired watchers
+        @observer = alight.observer.create()
+        @privateOb = @observer.observe @private
     @
 
 
 Root::destroy = ->
-    if @.observer
-        @.privateOb.destroy()
-        @.observer.destroy()
-    @.watchers.any.length = 0
-    @.watchers.finishBinding.length = 0
-    @.watchers.finishScan.length = 0
-    @.watchers.finishScanOnce.length = 0
+    if @observer
+        @privateOb.destroy()
+        @observer.destroy()
+    @watchers.any.length = 0
+    @watchers.finishBinding.length = 0
+    @watchers.finishScan.length = 0
+    @watchers.finishScanOnce.length = 0
 
 
 Root::node = (scope, option) ->
@@ -86,25 +86,25 @@ Root::node = (scope, option) ->
 
 Node = (root, scope, option) ->
     # local
-    @.scope = scope
-    @.root = root
-    @.watchers = {}
-    @.watchList = []
-    @.destroy_callbacks = []
+    @scope = scope
+    @root = root
+    @watchers = {}
+    @watchList = []
+    @destroy_callbacks = []
 
-    @.lineActive = false
-    @.prevSibling = null
-    @.nextSibling = null
+    @lineActive = false
+    @prevSibling = null
+    @nextSibling = null
 
     #
-    @.rwatchers =
+    @rwatchers =
         any: []
         finishScan: []
 
     if root.observer
         # local
-        @.obFire = {}
-        @.ob = root.observer.observe scope, option
+        @obFire = {}
+        @ob = root.observer.observe scope, option
     @
 
 
@@ -156,7 +156,7 @@ Node::destroy = ->
 
 
 WA = (callback) ->
-    @.cb = callback
+    @cb = callback
 
 watchAny = (node, key, callback) ->
     root = node.root
@@ -342,7 +342,7 @@ Node::watch = (name, callback, option) ->
 
 
 Node::compile = (src_exp, cfg) ->
-    scope = @.scope
+    scope = @scope
     cfg = cfg or {}
     # make hash
     resp = {}

--- a/alight/observer.coffee
+++ b/alight/observer.coffee
@@ -163,18 +163,18 @@ do ->
         if not f$.isObject scope
             throw 'Only objects can be observed'
 
-        @.id = getId()
-        @.active = true
-        @.observer = observer
-        @.rootEvent = null
-        @.keywords = {}
+        @id = getId()
+        @active = true
+        @observer = observer
+        @rootEvent = null
+        @keywords = {}
         if keywords
             for k in keywords
-                @.keywords[k] = true
+                @keywords[k] = true
 
-        @.scope = scope
-        @.wtree = {}  # store callbacks by keys
-        @.tree = tree = {}   # scope, path, isArray
+        @scope = scope
+        @wtree = {}  # store callbacks by keys
+        @tree = tree = {}   # scope, path, isArray
 
         observer.nodes.push @
 
@@ -200,11 +200,11 @@ do ->
         @
 
     Node::watch = (key, callback) ->
-        if not @.active
+        if not @active
             throw 'Inactive observer'
-        t = @.wtree
+        t = @wtree
         for k in key.split '.'
-            if @.keywords[k]
+            if @keywords[k]
                 return  # keyword in path of key
             if not t[k]
                 t[k] = {}
@@ -215,7 +215,7 @@ do ->
         callback
 
     Node::unwatch = (key, callback) ->
-        t = @.wtree
+        t = @wtree
         for k in key.split '.'
             c = t[k]
             if not c
@@ -225,13 +225,13 @@ do ->
         null
 
     Node::reobserve = (key) ->
-        if @.tree[key]
-            cleanTree @, @.tree[key]
-        if isObjectOrArray @.scope[key]
+        if @tree[key]
+            cleanTree @, @tree[key]
+        if isObjectOrArray @scope[key]
             ensureTree @, key
 
     Node::fire = (key, value) ->
-        t = @.wtree
+        t = @wtree
         for k in key.split '.'
             t = t[k] or {}
         if t[$cbs]
@@ -240,18 +240,18 @@ do ->
         null
 
     Node::destroy = ->
-        if not @.active
+        if not @active
             throw 'Inactive observer'
-        @.active = false
-        cleanTree @, @.tree
-        removeItem @.observer.nodes, @
+        @active = false
+        cleanTree @, @tree
+        removeItem @observer.nodes, @
 
 
     Observer = ->
         observer = @
-        @.nodes = []
-        @.treeByScope = new WeakMap()  # store trees by scopes
-        @.handler = (changes) ->
+        @nodes = []
+        @treeByScope = new WeakMap()  # store trees by scopes
+        @handler = (changes) ->
             for ch in changes
                 scope = ch.object
 
@@ -302,9 +302,9 @@ do ->
         n
 
     Observer::deliver = ->
-        Object.deliverChangeRecords @.handler
+        Object.deliverChangeRecords @handler
     Observer::destroy = ->
-        for n in @.nodes.slice()
+        for n in @nodes.slice()
             n.destroy()
         null
 

--- a/alight/scope.coffee
+++ b/alight/scope.coffee
@@ -87,7 +87,7 @@ Scope::$watch = (name, callback, option) ->
     if option is true
         option =
             isArray: true
-    @.$system.watch name, callback, option
+    @$system.watch name, callback, option
 
 
 ###
@@ -103,19 +103,19 @@ Scope::$watch = (name, callback, option) ->
 ###
 
 Scope::$compile = (src, option) ->
-    @.$system.compile src, option
+    @$system.compile src, option
 
 
 Scope::$eval = (exp) ->
-    @.$compile(exp, {noBind: true})(@)
+    @$compile(exp, {noBind: true})(@)
 
 
 Scope::$getValue = (name) ->
-    @.$eval name
+    @$eval name
 
 
 Scope::$setValue = (name, value) ->
-    fn = @.$compile name + ' = $value',
+    fn = @$compile name + ' = $value',
         input: ['$value']
         no_return: true
         noBind: true
@@ -160,7 +160,7 @@ Scope::$destroy = () ->
 
 
 Scope::$scanAsync = (callback) ->
-    @.$scan
+    @$scan
         late: true
         callback: callback
 
@@ -171,4 +171,4 @@ Scope::$scan = (option) ->
             callback: option
     else
         option = option or {}
-    @.$system.root.scan option
+    @$system.root.scan option


### PR DESCRIPTION
Hi,

translating "this.value" to CoffeeScript would be "@value" and not "@.value".
See http://coffeescript.org/#operators as example:
"As a shortcut for this.property, you can use @property."

So i replaced all occurences of "@." with "@", unittests are fine. 
