### PR TITLE
Update date.coffee

### DIFF
--- a/src/filter/date.coffee
+++ b/src/filter/date.coffee
@@ -9,6 +9,8 @@ alight.filters.date = do ->
         if not value
             return ''
 
+        value = new Date(value)
+        
         x = [
             [/yyyy/g, value.getFullYear()]
             [/mm/g, d2 value.getMonth() + 1]


### PR DESCRIPTION
added force conversion to the `date` filter (for cases where instead of date passed a number or a some valid string)

gulp tests are ok
