### PR TITLE
added charset meta tag to manual test runner

### DIFF
--- a/test/manual_test_dirs.html
+++ b/test/manual_test_dirs.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta charset="utf-8"/>
     <!--
         <link rel="stylesheet" type="text/css" href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" />
         <script type="text/javascript" src="http://code.jquery.com/jquery-1.10.2.min.js"></script>


### PR DESCRIPTION
Charset is required e.g. when running the html file directly from filesystem instead using a local webserver.
