### PR TITLE
Fix issue "Parent is null"

### DIFF
--- a/src/js/fquery.js
+++ b/src/js/fquery.js
@@ -2,14 +2,16 @@
 (function(){
     f$.before = function(base, elm) {
         var parent = base.parentNode;
-        parent.insertBefore(elm, base)
+        if(parent) parent.insertBefore(elm, base)
     };
 
     f$.after = function(base, elm) {
         var parent = base.parentNode;
-        var n = base.nextSibling;
-        if(n) parent.insertBefore(elm, n)
-        else parent.appendChild(elm)
+	if(parent)
+            var n = base.nextSibling;
+            if(n) parent.insertBefore(elm, n)
+            else parent.appendChild(elm)
+        }
     };
 
     f$.remove = function(elm) {


### PR DESCRIPTION
I've got error `parent is null` when update information with scope.$scan() after changing array with array splice.
The commit fixes this.
